### PR TITLE
Update youtube-dl from 2021.02.22 to 2021.03.02

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG GOLANG_VERSION=1.16.0
 # bump: youtube-dl /YDL_VERSION=([\d.]+)/ https://github.com/ytdl-org/youtube-dl.git|/^\d/|sort
 # bump: youtube-dl link "Release notes" https://github.com/ytdl-org/youtube-dl/releases/tag/$LATEST
-ARG YDL_VERSION=2021.02.22
+ARG YDL_VERSION=2021.03.02
 
 FROM golang:$GOLANG_VERSION
 ARG YDL_VERSION


### PR DESCRIPTION
[Release notes](https://github.com/ytdl-org/youtube-dl/releases/tag/2021.03.02)  
