### PR TITLE
Update yt-dlp from 2022.08.08 to 2022.08.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG GOLANG_VERSION=1.19.0
 # bump: yt-dlp /YT_DLP=([\d.-]+)/ https://github.com/yt-dlp/yt-dlp.git|/^\d/|sort
 # bump: yt-dlp link "Release notes" https://github.com/yt-dlp/yt-dlp/releases/tag/$LATEST
-ARG YT_DLP=2022.08.08
+ARG YT_DLP=2022.08.14
 
 FROM golang:$GOLANG_VERSION AS base
 ARG YT_DLP


### PR DESCRIPTION
[Release notes](https://github.com/yt-dlp/yt-dlp/releases/tag/2022.08.14)  
