### PR TITLE
Update yt-dlp to 2023.12.30 from 2023.11.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG GOLANG_VERSION=1.21.5
 # bump: yt-dlp /YT_DLP=([\d.-]+)/ https://github.com/yt-dlp/yt-dlp.git|/^\d/|sort
 # bump: yt-dlp link "Release notes" https://github.com/yt-dlp/yt-dlp/releases/tag/$LATEST
-ARG YT_DLP=2023.11.16
+ARG YT_DLP=2023.12.30
 
 FROM golang:$GOLANG_VERSION AS base
 ARG YT_DLP


### PR DESCRIPTION
[Release notes](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.12.30)  
