### PR TITLE
Remove --no-cahce-dir and add --netrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ func main() {
 See [goutubedl cmd tool](cmd/goutubedl/main.go) or [ydls](https://github.com/wader/ydls)
 for usage examples.
 
+### Default options and cache
+
+#### .netrc
+
+goutubedl by default uses `--netrc` to use `~/.netrc` authentication data.
+
+#### Cache directory
+
+yt-dlp stores various extractor session data to speed up things in `${XDG_CACHE_HOME}/yt-dlp` (usually `~/.cache/yt-dlp`). You might want to preverse this directory if your running things in ephemeral conatiners etc.
+
 ### Development
 
 ```sh

--- a/goutubedl.go
+++ b/goutubedl.go
@@ -304,13 +304,17 @@ func infoFromURL(
 		ProbePath(),
 		// see comment below about ignoring errors for playlists
 		"--ignore-errors",
+		// TODO: deprecated in yt-dlp?
 		"--no-call-home",
-		"--no-cache-dir",
-		"--skip-download",
+		// use safer output filenmaes
+		// TODO: needed?
 		"--restrict-filenames",
-		// provide URL via stdin for security, youtube-dl has some run command args
+		// use .netrc authentication data
+		"--netrc",
+		// provide url via stdin for security, youtube-dl has some run command args
 		"--batch-file", "-",
-		"-J",
+		// dump info json
+		"--dump-single-json",
 	)
 
 	if options.ProxyUrl != "" {
@@ -559,12 +563,19 @@ func (result Result) DownloadWithOptions(
 	cmd := exec.CommandContext(
 		ctx,
 		ProbePath(),
-		"--no-call-home",
-		"--no-cache-dir",
+		// see comment below about ignoring errors for playlists
 		"--ignore-errors",
+		// TODO: deprecated in yt-dlp?
+		"--no-call-home",
+		// use non-fancy progress bar
 		"--newline",
+		// use safer output filenmaes
+		// TODO: needed?
 		"--restrict-filenames",
-		"-o", "-",
+		// use .netrc authentication data
+		"--netrc",
+		// write to stdout
+		"--output", "-",
 	)
 
 	if result.Options.noInfoDownload {


### PR DESCRIPTION
--no-cache-dir was probably added in the belif to prevent storing big cache files but it seems to be extractor session data to speed up auth etc. --netrc is now default so that yt-dlp plugins works better

Fixes #187