### PR TITLE
impersonate support

### DIFF
--- a/goutubedl.go
+++ b/goutubedl.go
@@ -644,10 +644,6 @@ func (result Result) DownloadWithOptions(
 		cmd.Args = append(cmd.Args, "--audio-format", options.AudioFormats)
 	}
 
-	if result.Options.Impersonate != "" {
-		cmd.Args = append(cmd.Args, "--impersonate", result.Options.Impersonate)
-	}
-
 	if result.Options.ProxyUrl != "" {
 		cmd.Args = append(cmd.Args, "--proxy", result.Options.ProxyUrl)
 	}

--- a/goutubedl.go
+++ b/goutubedl.go
@@ -224,6 +224,7 @@ type Options struct {
 	DownloadThumbnail bool
 	DownloadSubtitles bool
 	DownloadSections  string // --download-sections
+	Impersonate       string // --impersonate
 
 	ProxyUrl           string // --proxy URL  http://host:port or socks5://host:port
 	UseIPV4            bool   // -4 Make all connections via IPv4
@@ -330,6 +331,10 @@ func infoFromURL(
 
 	if options.Downloader != "" {
 		cmd.Args = append(cmd.Args, "--downloader", options.Downloader)
+	}
+
+	if options.Impersonate != "" {
+		cmd.Args = append(cmd.Args, "--impersonate", options.Impersonate)
 	}
 
 	if options.Cookies != "" {
@@ -637,6 +642,10 @@ func (result Result) DownloadWithOptions(
 
 	if options.AudioFormats != "" {
 		cmd.Args = append(cmd.Args, "--audio-format", options.AudioFormats)
+	}
+
+	if result.Options.Impersonate != "" {
+		cmd.Args = append(cmd.Args, "--impersonate", result.Options.Impersonate)
 	}
 
 	if result.Options.ProxyUrl != "" {


### PR DESCRIPTION
From yt-dlp page:

> Client to impersonate for requests. E.g. chrome, chrome-110, chrome:windows-10. Pass --impersonate="" to impersonate any client.

This option requires yt-dlp 2024.04.09