### PR TITLE
Update yt-dlp to 2025.01.12 from 2024.12.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG GOLANG_VERSION=1.23.4
 # bump: yt-dlp /YT_DLP=([\d.-]+)/ https://github.com/yt-dlp/yt-dlp.git|/^\d/|sort
 # bump: yt-dlp link "Release notes" https://github.com/yt-dlp/yt-dlp/releases/tag/$LATEST
-ARG YT_DLP=2024.12.23
+ARG YT_DLP=2025.01.12
 
 FROM golang:$GOLANG_VERSION AS base
 ARG YT_DLP


### PR DESCRIPTION
[Release notes](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.01.12)  
