### PR TITLE
Update golang to 1.26.4 from 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # bump: golang /GOLANG_VERSION=([\d.]+)/ docker:golang|^1
 # bump: golang link "Release notes" https://golang.org/doc/devel/release.html
-ARG GOLANG_VERSION=1.26.3
+ARG GOLANG_VERSION=1.26.4
 # bump: yt-dlp /YT_DLP=([\d.-]+)/ https://github.com/yt-dlp/yt-dlp.git|/^\d/|sort
 # bump: yt-dlp link "Release notes" https://github.com/yt-dlp/yt-dlp/releases/tag/$LATEST
 ARG YT_DLP=2026.03.17


### PR DESCRIPTION
[Release notes](https://golang.org/doc/devel/release.html)  
